### PR TITLE
Move tokio to dev and add rt-multi-threaded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ include = [
 
 [dependencies]
 reqwest = { version = "0.11.0", features = ["json", "rustls-tls"], default-features = false }
-tokio = { version = "1.2", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }
 rustc-serialize = "0.3.24"
 enum-iterator = "0.6.0"
@@ -24,3 +23,6 @@ enum-iterator = "0.6.0"
 dotenv = "0.15.0"
 log = "0.4.8"
 env_logger = "0.8.2"
+
+[dev-dependencies]
+tokio = { version = "1.2", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Tokio is not needed in the main library and is only used for tests, and
thus can be safely moved to a dev-dependency.

The rt-multi-threaded feature of tokio is needed for some examples.

Fixes Issue #11. 