### PR TITLE
Add support for torrent-rename-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ spec: https://github.com/transmission/transmission/blob/master/extras/rpc-spec.t
 - [X] torrent-add
 - [X] torrent-remove
 - [X] torrent-set-location
-- [ ] torrent-rename-path
+- [X] torrent-rename-path
 - [ ] session-set
 - [X] session-get
 - [ ] session-stats

--- a/examples/torrent-rename-path.rs
+++ b/examples/torrent-rename-path.rs
@@ -1,0 +1,20 @@
+extern crate transmission_rpc;
+
+use std::env;
+use dotenv::dotenv;
+use transmission_rpc::TransClient;
+use transmission_rpc::types::{Result, RpcResponse, BasicAuth};
+use transmission_rpc::types::{TorrentRenamePath, Id};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv().ok();
+    env_logger::init();
+    let url= env::var("TURL")?;
+    let basic_auth = BasicAuth{user: env::var("TUSER")?, password: env::var("TPWD")?};
+    let client = TransClient::with_auth(&url, basic_auth);
+    let res: RpcResponse<TorrentRenamePath> = client.torrent_rename_path(vec![Id::Id(1)], String::from("Folder/OldFile.jpg"), String::from("NewFile.jpg")).await?;
+    println!("rename-path result: {:#?}", res);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use types::BasicAuth;
 use types::SessionGet;
 use types::TorrentAction;
 use types::{Id, Torrent, TorrentGetField, Torrents};
-use types::{Nothing, Result, RpcRequest, RpcResponse, RpcResponseArgument};
+use types::{Nothing, Result, RpcRequest, RpcResponse, RpcResponseArgument, TorrentRenamePath};
 use types::{TorrentAddArgs, TorrentAdded};
 
 pub struct TransClient {
@@ -285,6 +285,46 @@ impl TransClient {
         move_from: Option<bool>,
     ) -> Result<RpcResponse<Nothing>> {
         self.call(RpcRequest::torrent_set_location(ids, location, move_from))
+            .await
+    }
+
+    /// Performs a torrent rename path call
+    ///
+    /// # Errors
+    ///
+    /// Any IO Error or Deserialization error
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate transmission_rpc;
+    /// 
+    /// use std::env;
+    /// use dotenv::dotenv;
+    /// use transmission_rpc::TransClient;
+    /// use transmission_rpc::types::{Result, RpcResponse, BasicAuth};
+    /// use transmission_rpc::types::{TorrentRenamePath, Id};
+    /// 
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     dotenv().ok();
+    ///     env_logger::init();
+    ///     let url= env::var("TURL")?;
+    ///     let basic_auth = BasicAuth{user: env::var("TUSER")?, password: env::var("TPWD")?};
+    ///     let client = TransClient::with_auth(&url, basic_auth);
+    ///     let res: RpcResponse<TorrentRenamePath> = client.torrent_rename_path(vec![Id::Id(1)], String::from("Folder/OldFile.jpg"), String::from("NewFile.jpg")).await?;
+    ///     println!("rename-path result: {:#?}", res);
+    /// 
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn torrent_rename_path(
+        &self,
+        ids: Vec<Id>,
+        path: String,
+        name: String,
+    ) -> Result<RpcResponse<TorrentRenamePath>> {
+        self.call(RpcRequest::torrent_rename_path(ids, path, name))
             .await
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use self::request::RpcRequest;
 pub use self::request::TorrentAction;
 pub use self::request::TorrentAddArgs;
 pub use self::request::TorrentGetField;
+pub use self::request::TorrentRenamePathArgs;
 
 pub use self::response::Nothing;
 pub use self::response::RpcResponse;
@@ -23,3 +24,4 @@ pub use self::response::SessionGet;
 pub use self::response::Torrent;
 pub use self::response::TorrentAdded;
 pub use self::response::Torrents;
+pub use self::response::TorrentRenamePath;

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -65,6 +65,17 @@ impl RpcRequest {
             })),
         }
     }
+
+    pub fn torrent_rename_path(ids: Vec<Id>, path: String, name: String) -> RpcRequest {
+        RpcRequest {
+            method: String::from("torrent-rename-path"),
+            arguments: Some(Args::TorrentRenamePathArgs(TorrentRenamePathArgs {
+                ids,
+                path,
+                name
+            }))
+        }
+    }
 }
 pub trait ArgumentFields {}
 impl ArgumentFields for TorrentGetField {}
@@ -77,6 +88,7 @@ pub enum Args {
     TorrentRemoveArgs(TorrentRemoveArgs),
     TorrentAddArgs(TorrentAddArgs),
     TorrentSetLocationArgs(TorrentSetLocationArgs),
+    TorrentRenamePathArgs(TorrentRenamePathArgs),
 }
 
 #[derive(Serialize, Debug, RustcEncodable, Clone)]
@@ -116,6 +128,13 @@ pub struct TorrentSetLocationArgs {
     location: String,
     #[serde(skip_serializing_if = "Option::is_none", rename = "move")]
     move_from: Option<bool>,
+}
+
+#[derive(Serialize, Debug, RustcEncodable, Clone)]
+pub struct TorrentRenamePathArgs {
+    ids: Vec<Id>,
+    path: String,
+    name: String,
 }
 
 #[derive(Serialize, Debug, RustcEncodable, Clone)]

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -123,3 +123,12 @@ pub struct TorrentAdded {
     pub torrent_added: Option<Torrent>,
 }
 impl RpcResponseArgument for TorrentAdded {}
+
+#[derive(Deserialize, Debug, RustcEncodable)]
+pub struct TorrentRenamePath{
+    pub path: String,
+    pub name: String,
+    pub id: i64
+
+}
+impl RpcResponseArgument for TorrentRenamePath {}


### PR DESCRIPTION
Support includes examples in the documentation and an updated readme to reflect the support.