### PR TITLE
Handle adding duplicated torrent.

### DIFF
--- a/examples/torrent-add.rs
+++ b/examples/torrent-add.rs
@@ -3,7 +3,7 @@ extern crate transmission_rpc;
 use dotenv::dotenv;
 use std::env;
 use transmission_rpc::types::{BasicAuth, Result, RpcResponse};
-use transmission_rpc::types::{TorrentAddArgs, TorrentAdded};
+use transmission_rpc::types::{TorrentAddArgs, TorrentAddedOrDuplicate};
 use transmission_rpc::TransClient;
 
 #[tokio::main]
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
         filename: Some("https://releases.ubuntu.com/20.04/ubuntu-20.04.2.0-desktop-amd64.iso.torrent".to_string()),
         ..TorrentAddArgs::default()
     };
-    let res: RpcResponse<TorrentAdded> = client.torrent_add(add).await?;
+    let res: RpcResponse<TorrentAddedOrDuplicate> = client.torrent_add(add).await?;
     println!("Add result: {:?}", &res.is_ok());
     println!("response: {:?}", &res);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use types::FreeSpace;
 use types::TorrentAction;
 use types::{Id, Torrent, TorrentGetField, Torrents};
 use types::{Nothing, Result, RpcRequest, RpcResponse, RpcResponseArgument, TorrentRenamePath};
-use types::{TorrentAddArgs, TorrentAdded};
+use types::{TorrentAddArgs, TorrentAddedOrDuplicate};
 
 const MAX_RETRIES: usize = 5;
 
@@ -527,7 +527,7 @@ impl TransClient {
     /// use dotenv::dotenv;
     /// use transmission_rpc::TransClient;
     /// use transmission_rpc::types::{Result, RpcResponse, BasicAuth};
-    /// use transmission_rpc::types::{TorrentAddArgs, TorrentAdded};
+    /// use transmission_rpc::types::{TorrentAddArgs, TorrentAddedOrDuplicate};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
@@ -540,7 +540,7 @@ impl TransClient {
     ///         filename: Some("https://releases.ubuntu.com/20.04/ubuntu-20.04-desktop-amd64.iso.torrent".to_string()),
     ///         ..TorrentAddArgs::default()
     ///     };
-    ///     let res: RpcResponse<TorrentAdded> = client.torrent_add(add).await?;
+    ///     let res: RpcResponse<TorrentAddedOrDuplicate> = client.torrent_add(add).await?;
     ///     println!("Add result: {:?}", &res.is_ok());
     ///     println!("response: {:?}", &res);
     ///

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -27,6 +27,6 @@ pub use self::response::BlocklistUpdate;
 pub use self::response::PortTest;
 pub use self::response::FreeSpace;
 pub use self::response::Torrent;
-pub use self::response::TorrentAdded;
+pub use self::response::TorrentAddedOrDuplicate;
 pub use self::response::Torrents;
 pub use self::response::TorrentRenamePath;

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -179,11 +179,12 @@ pub struct Nothing {}
 impl RpcResponseArgument for Nothing {}
 
 #[derive(Deserialize, Debug)]
-pub struct TorrentAdded {
-    #[serde(rename = "torrent-added")]
-    pub torrent_added: Option<Torrent>,
+#[serde(rename_all="kebab-case")]
+pub enum TorrentAddedOrDuplicate {
+    TorrentDuplicate(Torrent),
+    TorrentAdded(Torrent),
 }
-impl RpcResponseArgument for TorrentAdded {}
+impl RpcResponseArgument for TorrentAddedOrDuplicate {}
 
 #[derive(Deserialize, Debug)]
 pub struct TorrentRenamePath{


### PR DESCRIPTION
Starting from Transmission 2.80 (rpc-version-semver 5.1.0, rpc-version:
15) 'torrent-add' could return 'torrent-duplicated' from torrent-add if
the torrent already exists. Replace 'TorrentAdded' with
'TorrentAddedOrDuplicate'.