### PR TITLE
SharableTransClient: take `&self` for rpc methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["transmission", "torrent", "jrpc"]
 categories = ["api-bindings"]
 include = ["**/*.rs", "Cargo.toml"]
 
+[features]
+sync = []
+
 [dependencies]
 reqwest = { version = "0.11.11", features = [
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "transmission-rpc"
-version = "0.3.7"
-authors = ["red <red.avtovo@gmail.com>"]
+version = "0.4.0"
+authors = ["red <red.avtovo@gmail.com>", "George Miao <gm@miao.dev>"]
 edition = "2021"
 repository = "https://github.com/j0rsa/transmission-rpc"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_repr = "0.1"
 enum-iterator = "1.2.0"
 
-dotenvy = "0.15.5"
 log = "0.4.17"
-env_logger = "0.9.1"
 
 [dev-dependencies]
+env_logger = "0.9.1"
+dotenvy = "0.15.5"
 tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread"] }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+version = "Two"
+
+wrap_comments = true
+normalize_comments = true
+
+use_field_init_shorthand = true
+
+format_strings = true
+format_code_in_doc_comments = true
+format_macro_matchers = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,20 @@ impl TransClient {
         }
     }
 
+    #[must_use]
+    pub fn new_with_client(url: Url, client: Client) -> TransClient {
+        TransClient {
+            url,
+            auth: None,
+            session_id: None,
+            client,
+        }
+    }
+
+    pub fn set_auth(&mut self, basic_auth: BasicAuth) {
+        self.auth = Some(basic_auth);
+    }
+
     /// Prepares a request for provided server and auth
     fn rpc_request(&self) -> reqwest::RequestBuilder {
         if let Some(auth) = &self.auth {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -809,6 +809,7 @@ mod tests {
         dotenv().ok();
         env_logger::init();
         let url = env::var("TURL")?;
+
         let mut client;
         if let (Ok(user), Ok(password)) = (env::var("TUSER"), env::var("TPWD")) {
             client = TransClient::with_auth(url.parse()?, BasicAuth { user, password });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,13 @@ extern crate log;
 use reqwest::{header::CONTENT_TYPE, Client, StatusCode, Url};
 use serde::de::DeserializeOwned;
 
+#[cfg(feature = "sync")]
 mod sync;
-pub mod types;
-
+#[cfg(feature = "sync")]
 pub use sync::SharableTransClient;
+
+
+pub mod types;
 use types::{
     BasicAuth, BlocklistUpdate, FreeSpace, Id, Nothing, PortTest, Result, RpcRequest, RpcResponse,
     RpcResponseArgument, SessionClose, SessionGet, SessionStats, Torrent, TorrentAction,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@ use serde::de::DeserializeOwned;
 
 #[cfg(feature = "sync")]
 mod sync;
+
 #[cfg(feature = "sync")]
 pub use sync::SharableTransClient;
-
 
 pub mod types;
 use types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,14 +764,14 @@ impl TransClient {
                 .checked_sub(1)
                 .ok_or(TransError::MaxRetriesReached)?;
 
-            info!("Loaded auth: {:?}", &self.auth);
+            debug!("Loaded auth: {:?}", &self.auth);
             let rq = match &self.session_id {
                 None => self.rpc_request(),
                 Some(id) => self.rpc_request().header("X-Transmission-Session-Id", id),
             }
             .json(&request);
 
-            info!(
+            debug!(
                 "Request body: {:?}",
                 rq.try_clone()
                     .expect("Unable to get the request body")
@@ -787,10 +787,10 @@ impl TransClient {
                     .to_str()?;
                 self.session_id = Some(String::from(session_id));
 
-                info!("Got new session_id: {}. Retrying request.", session_id);
+                debug!("Got new session_id: {}. Retrying request.", session_id);
             } else {
                 let rpc_response: RpcResponse<RS> = rsp.json().await?;
-                info!("Response body: {:#?}", rpc_response);
+                debug!("Response body: {:#?}", rpc_response);
 
                 return Ok(rpc_response);
             }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,3 +1,9 @@
+//! Sharable version of `TransClient`.
+//!
+//! It lifted the requirement of `&mut self` on
+//! all requests methods by using a lock on inner state. This may introduce some overhead
+//! so choose as needed.
+
 use std::{ops::Deref, sync::RwLock};
 
 use reqwest::{header::CONTENT_TYPE, Client, StatusCode, Url};

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,8 +1,8 @@
 //! Sharable version of `TransClient`.
 //!
 //! It lifted the requirement of `&mut self` on
-//! all requests methods by using a lock on inner state. This may introduce some overhead
-//! so choose as needed.
+//! all requests methods by using a lock on inner state. This may introduce some
+//! overhead so choose as needed.
 
 use std::{ops::Deref, sync::RwLock};
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -10,25 +10,8 @@ use crate::{
         TorrentAction, TorrentAddArgs, TorrentAddedOrDuplicate, TorrentGetField, TorrentRenamePath,
         TorrentSetArgs, Torrents,
     },
-    MAX_RETRIES,
+    BodyString, TransError, MAX_RETRIES,
 };
-
-#[derive(Clone, Debug)]
-enum TransError {
-    MaxRetriesReached,
-    NoSessionIdReceived,
-}
-
-impl std::fmt::Display for TransError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            TransError::MaxRetriesReached => write!(f, "Max retries reached!"),
-            TransError::NoSessionIdReceived => write!(f, "No session id received!"),
-        }
-    }
-}
-
-impl std::error::Error for TransError {}
 
 pub struct SharableTransClient {
     url: Url,
@@ -100,7 +83,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<SessionGet>> = client.session_get().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -110,7 +93,7 @@ impl SharableTransClient {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn session_get(&mut self) -> Result<RpcResponse<SessionGet>> {
+    pub async fn session_get(&self) -> Result<RpcResponse<SessionGet>> {
         self.call(RpcRequest::session_get()).await
     }
 
@@ -142,7 +125,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<SessionStats>> = client.session_stats().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -152,7 +135,7 @@ impl SharableTransClient {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn session_stats(&mut self) -> Result<RpcResponse<SessionStats>> {
+    pub async fn session_stats(&self) -> Result<RpcResponse<SessionStats>> {
         self.call(RpcRequest::session_stats()).await
     }
 
@@ -184,7 +167,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<SessionClose>> = client.session_close().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -194,7 +177,7 @@ impl SharableTransClient {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn session_close(&mut self) -> Result<RpcResponse<SessionClose>> {
+    pub async fn session_close(&self) -> Result<RpcResponse<SessionClose>> {
         self.call(RpcRequest::session_close()).await
     }
 
@@ -226,7 +209,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<BlocklistUpdate>> = client.blocklist_update().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -236,7 +219,7 @@ impl SharableTransClient {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn blocklist_update(&mut self) -> Result<RpcResponse<BlocklistUpdate>> {
+    pub async fn blocklist_update(&self) -> Result<RpcResponse<BlocklistUpdate>> {
         self.call(RpcRequest::blocklist_update()).await
     }
 
@@ -269,7 +252,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<FreeSpace>> = client.free_space(dir).await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -311,7 +294,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<PortTest>> = client.port_test().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -321,7 +304,7 @@ impl SharableTransClient {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn port_test(&mut self) -> Result<RpcResponse<PortTest>> {
+    pub async fn port_test(&self) -> Result<RpcResponse<PortTest>> {
         self.call(RpcRequest::port_test()).await
     }
 
@@ -355,7 +338,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///
     ///     let res: RpcResponse<Torrents<Torrent>> = client.torrent_get(None, None).await?;
     ///     let names: Vec<&String> = res
@@ -455,7 +438,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url, basic_auth);
+    ///     let  client = TransClient::with_auth(url, basic_auth);
     ///
     ///     let args = TorrentSetArgs {
     ///         labels: Some(vec![String::from("blue")]),
@@ -507,7 +490,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let res1: RpcResponse<Nothing> = client
     ///         .torrent_action(TorrentAction::Start, vec![Id::Id(1)])
     ///         .await?;
@@ -556,7 +539,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let res: RpcResponse<Nothing> = client.torrent_remove(vec![Id::Id(1)], false).await?;
     ///     println!("Remove result: {:?}", &res.is_ok());
     ///
@@ -600,7 +583,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let res: RpcResponse<Nothing> = client
     ///         .torrent_set_location(
     ///             vec![Id::Id(1)],
@@ -651,7 +634,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let res: RpcResponse<TorrentRenamePath> = client
     ///         .torrent_rename_path(
     ///             vec![Id::Id(1)],
@@ -702,7 +685,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let add: TorrentAddArgs = TorrentAddArgs {
     ///         filename: Some(
     ///             "https://releases.ubuntu.com/jammy/ubuntu-22.04.1-desktop-amd64.iso.torrent"
@@ -781,18 +764,6 @@ impl SharableTransClient {
     }
 }
 
-trait BodyString {
-    fn body_string(self) -> Result<String>;
-}
-
-impl BodyString for reqwest::RequestBuilder {
-    fn body_string(self) -> Result<String> {
-        let rq = self.build()?;
-        let body = rq.body().unwrap().as_bytes().unwrap();
-        Ok(std::str::from_utf8(body)?.to_string())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::env;
@@ -806,7 +777,7 @@ mod tests {
         dotenv().ok();
         env_logger::init();
         let url = env::var("TURL")?;
-        let mut client;
+        let client;
         if let (Ok(user), Ok(password)) = (env::var("TUSER"), env::var("TPWD")) {
             client = SharableTransClient::with_auth(url.parse()?, BasicAuth { user, password });
         } else {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -97,7 +97,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<SessionGet>> = client.session_get().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -139,7 +139,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<SessionStats>> = client.session_stats().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -181,7 +181,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<SessionClose>> = client.session_close().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -223,7 +223,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<BlocklistUpdate>> = client.blocklist_update().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -266,7 +266,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<FreeSpace>> = client.free_space(dir).await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -308,7 +308,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let response: Result<RpcResponse<PortTest>> = client.port_test().await;
     ///     match response {
     ///         Ok(_) => println!("Yay!"),
@@ -352,7 +352,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///
     ///     let res: RpcResponse<Torrents<Torrent>> = client.torrent_get(None, None).await?;
     ///     let names: Vec<&String> = res
@@ -452,7 +452,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url, basic_auth);
     ///
     ///     let args = TorrentSetArgs {
     ///         labels: Some(vec![String::from("blue")]),
@@ -504,7 +504,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let res1: RpcResponse<Nothing> = client
     ///         .torrent_action(TorrentAction::Start, vec![Id::Id(1)])
     ///         .await?;
@@ -553,7 +553,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let res: RpcResponse<Nothing> = client.torrent_remove(vec![Id::Id(1)], false).await?;
     ///     println!("Remove result: {:?}", &res.is_ok());
     ///
@@ -597,7 +597,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let res: RpcResponse<Nothing> = client
     ///         .torrent_set_location(
     ///             vec![Id::Id(1)],
@@ -648,7 +648,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let res: RpcResponse<TorrentRenamePath> = client
     ///         .torrent_rename_path(
     ///             vec![Id::Id(1)],
@@ -699,7 +699,7 @@ impl SharableTransClient {
     ///         user: env::var("TUSER")?,
     ///         password: env::var("TPWD")?,
     ///     };
-    ///     let  client = TransClient::with_auth(url.parse()?, basic_auth);
+    ///     let client = SharableTransClient::with_auth(url.parse()?, basic_auth);
     ///     let add: TorrentAddArgs = TorrentAddArgs {
     ///         filename: Some(
     ///             "https://releases.ubuntu.com/jammy/ubuntu-22.04.1-desktop-amd64.iso.torrent"
@@ -758,6 +758,8 @@ impl SharableTransClient {
             );
 
             let rsp: reqwest::Response = rq.send().await?;
+
+            info!("Response: {:?}", &rsp);
             if matches!(rsp.status(), StatusCode::CONFLICT) {
                 let session_id = rsp
                     .headers()

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -743,14 +743,14 @@ impl SharableTransClient {
                 .checked_sub(1)
                 .ok_or(TransError::MaxRetriesReached)?;
 
-            info!("Loaded auth: {:?}", &self.auth);
+            debug!("Loaded auth: {:?}", &self.auth);
             let rq = match &self.session_id.read().expect("lock being poisoned").deref() {
                 None => self.rpc_request(),
                 Some(id) => self.rpc_request().header("X-Transmission-Session-Id", id),
             }
             .json(&request);
 
-            info!(
+            debug!(
                 "Request body: {:?}",
                 rq.try_clone()
                     .expect("Unable to get the request body")
@@ -767,10 +767,10 @@ impl SharableTransClient {
                 *self.session_id.write().expect("lock being poisoned") =
                     Some(String::from(session_id));
 
-                info!("Got new session_id: {}. Retrying request.", session_id);
+                debug!("Got new session_id: {}. Retrying request.", session_id);
             } else {
                 let rpc_response: RpcResponse<RS> = rsp.json().await?;
-                info!("Response body: {:#?}", rpc_response);
+                debug!("Response body: {:#?}", rpc_response);
 
                 return Ok(rpc_response);
             }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -797,7 +797,8 @@ mod tests {
     #[tokio::test]
     pub async fn test_malformed_url() -> Result<()> {
         dotenv().ok();
-        env_logger::init();
+        // To prevent double init
+        let _ = env_logger::try_init();
         let url = env::var("TURL")?;
         let client;
         if let (Ok(user), Ok(password)) = (env::var("TUSER"), env::var("TPWD")) {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -43,6 +43,20 @@ impl SharableTransClient {
         }
     }
 
+    #[must_use]
+    pub fn new_with_client(url: Url, client: Client) -> SharableTransClient {
+        SharableTransClient {
+            url,
+            auth: None,
+            session_id: RwLock::new(None),
+            client,
+        }
+    }
+
+    pub fn set_auth(&mut self, basic_auth: BasicAuth) {
+        self.auth = Some(basic_auth);
+    }
+
     /// Prepares a request for provided server and auth
     fn rpc_request(&self) -> reqwest::RequestBuilder {
         if let Some(auth) = &self.auth {

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -218,7 +218,8 @@ pub struct TorrentAddArgs {
     #[serde(skip_serializing_if = "Option::is_none", rename = "bandwidthPriority")]
     pub bandwidth_priority: Option<i64>,
     /// list of indices of files to be downloaded
-    /// to ignore some files, put their indices in files_unwanted, otherwise they will still be downloaded
+    /// to ignore some files, put their indices in files_unwanted, otherwise
+    /// they will still be downloaded
     #[serde(skip_serializing_if = "Option::is_none", rename = "files-wanted")]
     pub files_wanted: Option<Vec<i32>>,
     /// list of indices of files not to download


### PR DESCRIPTION
This PR adds a `SharableTransClient` which uses `RwLock` for shared mutability of session id, and minor changes on dependency. More detail discussed [here](https://github.com/j0rsa/transmission-rpc/issues/19#issuecomment-1284358118). Sorry for messing up with the format.