### PR TITLE
fix: wrong logging level

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -765,7 +765,7 @@ impl SharableTransClient {
 
             let rsp: reqwest::Response = rq.send().await?;
 
-            info!("Response: {:?}", &rsp);
+            debug!("Response: {:?}", &rsp);
             if matches!(rsp.status(), StatusCode::CONFLICT) {
                 let session_id = rsp
                     .headers()


### PR DESCRIPTION
I don't remember exactly why but I added one line that log out every response body with level `info` in the sync module. This PR fixes it.

[This commit](https://github.com/j0rsa/transmission-rpc/commit/69760035f3d932af2ed51b9b499f80f621e91000#diff-44e47ea9be0c53791e7aed4ba12a105bc663405ad3dec0008bc90c85505e1e11R762)