### PR TITLE
Improve tracker handling

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -19,4 +19,5 @@ pub(crate) use self::response::RpcResponseArgument;
 pub use self::response::{
     BlocklistUpdate, FreeSpace, Nothing, PortTest, RpcResponse, SessionClose, SessionGet,
     SessionStats, Torrent, TorrentAddedOrDuplicate, TorrentRenamePath, TorrentStatus, Torrents,
+    Tracker,
 };

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -416,7 +416,7 @@ pub struct TorrentSetArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tracker_list: Option<TrackerList>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tracker_remove: Option<Vec<String>>,
+    pub tracker_remove: Option<Vec<i32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tracker_replace: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -114,7 +114,7 @@ pub struct Torrent {
     pub status: Option<TorrentStatus>,
     pub torrent_file: Option<String>,
     pub total_size: Option<i64>,
-    pub trackers: Option<Vec<Trackers>>,
+    pub trackers: Option<Vec<Tracker>>,
     pub upload_ratio: Option<f32>,
     pub uploaded_ever: Option<i64>,
     pub files: Option<Vec<File>>,
@@ -152,7 +152,7 @@ pub struct Torrents<T> {
 impl RpcResponseArgument for Torrents<Torrent> {}
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct Trackers {
+pub struct Tracker {
     pub id: i32,
     pub announce: String,
 }


### PR DESCRIPTION
- Rename `Trackers` type to `Tracker`, as instances contain a single tracker. Field `Torrent.trackers` may hold a `Vec<Tracker>` (https://docs.rs/transmission-rpc/0.4.0/transmission_rpc/types/struct.Torrent.html#structfield.trackers).
- Expose it: it's simple and meaningful enough, and avoids an opaque type in `Torrent.trackers`.
- Fix the method `tracker_remove` as it expects a list of integer tracker IDs, not URLs (https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#32-torrent-mutator-torrent-set).