### PR TITLE
Fix test for torrent-add

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,7 +726,7 @@ impl TransClient {
     ///     let mut client = TransClient::with_auth(url.parse()?, basic_auth);
     ///     let add: TorrentAddArgs = TorrentAddArgs {
     ///         filename: Some(
-    ///             "https://releases.ubuntu.com/jammy/ubuntu-22.04.1-desktop-amd64.iso.torrent"
+    ///             "https://releases.ubuntu.com/22.04/ubuntu-22.04.3-desktop-amd64.iso.torrent"
     ///                 .to_string(),
     ///         ),
     ///         ..TorrentAddArgs::default()


### PR DESCRIPTION
Fixed test for torrent-add.

I update Ubuntu ISO torrent URL, by the way  it must be vanish again after some months. It should  be good that looking  forward a some permanent URL.