### PR TITLE
Expose RpcResponseArgument type

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,9 +15,8 @@ pub use self::request::{
     TorrentRenamePathArgs, TorrentSetArgs, TrackerList,
 };
 
-pub(crate) use self::response::RpcResponseArgument;
 pub use self::response::{
-    BlocklistUpdate, ErrorType, FreeSpace, Nothing, PortTest, RpcResponse, SessionClose,
-    SessionGet, SessionSet, SessionStats, Torrent, TorrentAddedOrDuplicate, TorrentRenamePath,
-    TorrentStatus, Torrents,
+    BlocklistUpdate, ErrorType, FreeSpace, Nothing, PortTest, RpcResponse, RpcResponseArgument,
+    SessionClose, SessionGet, SessionSet, SessionStats, Torrent, TorrentAddedOrDuplicate,
+    TorrentRenamePath, TorrentStatus, Torrents,
 };


### PR DESCRIPTION
I'm not sure if there's a good reason for it to be kept private.
It blocks creating generic functions over the RPC responses, such as logging every response.