### PR TITLE
Add bandwidth_priority to torrent set args

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,7 +11,7 @@ pub struct BasicAuth {
 
 pub(crate) use self::request::RpcRequest;
 pub use self::request::{
-    ArgumentFields, Id, SessionSetArgs, TorrentAction, TorrentAddArgs, TorrentGetField,
+    ArgumentFields, Id, Priority, SessionSetArgs, TorrentAction, TorrentAddArgs, TorrentGetField,
     TorrentRenamePathArgs, TorrentSetArgs, TrackerList,
 };
 

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -466,6 +466,7 @@ pub struct TorrentAddArgs {
 pub enum TorrentGetField {
     ActivityDate,
     AddedDate,
+    BandwidthPriority,
     DoneDate,
     DownloadDir,
     EditDate,
@@ -513,6 +514,7 @@ impl TorrentGetField {
         match self {
             TorrentGetField::ActivityDate => "activityDate",
             TorrentGetField::AddedDate => "addedDate",
+            TorrentGetField::BandwidthPriority => "bandwidthPriority",
             TorrentGetField::DoneDate => "doneDate",
             TorrentGetField::DownloadDir => "downloadDir",
             TorrentGetField::EditDate => "editDate",

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -1,5 +1,6 @@
 use enum_iterator::{all, Sequence};
 use serde::Serialize;
+use serde_repr::Deserialize_repr;
 
 #[derive(Serialize, Debug)]
 pub struct RpcRequest {
@@ -420,6 +421,14 @@ pub enum Id {
     Hash(String),
 }
 
+#[derive(Serialize, Deserialize_repr, Debug, Clone, PartialEq, Eq)]
+#[repr(i8)]
+pub enum Priority {
+    Low = -1,
+    Normal = 0,
+    High = 1,
+}
+
 #[derive(Serialize, Debug, Clone, Default)]
 pub struct TorrentAddArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -440,7 +449,7 @@ pub struct TorrentAddArgs {
     #[serde(skip_serializing_if = "Option::is_none", rename = "peer-limit")]
     pub peer_limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bandwidthPriority")]
-    pub bandwidth_priority: Option<i64>,
+    pub bandwidth_priority: Option<Priority>,
     /// list of indices of files to be downloaded
     /// to ignore some files, put their indices in files_unwanted, otherwise
     /// they will still be downloaded
@@ -598,7 +607,7 @@ impl Serialize for TrackerList {
 #[serde(rename_all = "camelCase")]
 pub struct TorrentSetArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bandwidth_priority: Option<i64>,
+    pub bandwidth_priority: Option<Priority>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub download_limit: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use serde_repr::*;
 
+use crate::types::request::Priority;
 use crate::types::Id;
 
 #[derive(Deserialize, Debug)]
@@ -99,7 +100,7 @@ pub enum ErrorType {
 pub struct Torrent {
     pub activity_date: Option<i64>,
     pub added_date: Option<i64>,
-    pub bandwidth_priority: Option<i64>,
+    pub bandwidth_priority: Option<Priority>,
     pub done_date: Option<i64>,
     pub download_dir: Option<String>,
     pub edit_date: Option<i64>,
@@ -134,8 +135,7 @@ pub struct Torrent {
     pub files: Option<Vec<File>>,
     /// for each file in files, whether or not they will be downloaded (0 or 1)
     pub wanted: Option<Vec<i8>>,
-    /// for each file in files, their download priority (low:-1,normal:0,high:1)
-    pub priorities: Option<Vec<i8>>,
+    pub priorities: Option<Vec<Priority>>,
     pub file_stats: Option<Vec<FileStat>>,
     #[serde(rename = "file-count")]
     pub file_count: Option<usize>,
@@ -186,8 +186,7 @@ pub struct File {
 pub struct FileStat {
     pub bytes_completed: i64,
     pub wanted: bool,
-    /// low: -1, normal: 0, high: 1
-    pub priority: i8,
+    pub priority: Priority,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -99,6 +99,7 @@ pub enum ErrorType {
 pub struct Torrent {
     pub activity_date: Option<i64>,
     pub added_date: Option<i64>,
+    pub bandwidth_priority: Option<i64>,
     pub done_date: Option<i64>,
     pub download_dir: Option<String>,
     pub edit_date: Option<i64>,


### PR DESCRIPTION
- Add bandwidth_priority to torrent set API call arguments
- Represent bandwidth priority by Enum value