### PR TITLE
fixed Rpc error when RpcResponseArgument is empty after torrent_add call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ log = "0.4.20"
 env_logger = "0.10.0"
 dotenvy = "0.15.7"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
+serde_json = "1"


### PR DESCRIPTION
Hi,
while using this library, I found it difficult to debug my program when torrent_add returned an error, because of the empty "arguments" returned by transmission.

With this patch, the TorrentAddOrDuplicate enum contains an Error alternative, and Transmission's message can be accessed in the "result" field of the RpcResponse.