### PR TITLE
Add protocol and throttling fields to SessionGet

### DIFF
--- a/examples/session-get.rs
+++ b/examples/session-get.rs
@@ -24,27 +24,103 @@ async fn main() -> Result<()> {
             println!("version: {}", s.version);
             println!("rpc-version: {}", s.rpc_version);
             println!("rpc-version-minimum: {}", s.rpc_version_minimum);
+            println!("rpc-version-semver: {}", s.rpc_version_semver);
+            println!("session-id: {}", s.session_id);
+            println!("config-dir: {}", s.config_dir);
             println!("download-dir: {}", s.download_dir);
-            println!("encryption: {}", s.encryption);
-            println!("peer-port: {}", s.peer_port);
-            println!("blocklist-enabled: {}", s.blocklist_enabled);
-            println!("incomplete-dir-enabled: {:?}", s.incomplete_dir_enabled);
-            println!("incomplete-dir: {:?}", s.incomplete_dir);
+            println!("incomplete-dir-enabled: {}", s.incomplete_dir_enabled);
+            println!("incomplete-dir: {}", s.incomplete_dir);
+            println!("rename-partial-files: {}", s.rename_partial_files);
             println!(
-                "script-torrent-done-enabled: {:?}",
+                "trash-original-torrent-files: {}",
+                s.trash_original_torrent_files
+            );
+            println!("start-added-torrents: {}", s.start_added_torrents);
+            println!("encryption: {}", s.encryption);
+            println!("cache-size-mb: {}", s.cache_size_mb);
+            println!("default-trackers: {}", s.default_trackers);
+
+            // Port / transport.
+            println!("peer-port: {}", s.peer_port);
+            println!("peer-port-random-on-start: {}", s.peer_port_random_on_start);
+            println!("port-forwarding-enabled: {}", s.port_forwarding_enabled);
+            println!("utp-enabled: {}", s.utp_enabled);
+            println!("pex-enabled: {}", s.pex_enabled);
+            println!("dht-enabled: {}", s.dht_enabled);
+            println!("lpd-enabled: {}", s.lpd_enabled);
+            println!("preferred-transports: {:?}", s.preferred_transports);
+
+            // Blocklist.
+            println!("blocklist-enabled: {}", s.blocklist_enabled);
+            println!("blocklist-url: {}", s.blocklist_url);
+            println!("blocklist-size: {}", s.blocklist_size);
+
+            // RPC server protections.
+            println!("anti-brute-force-enabled: {}", s.anti_brute_force_enabled);
+
+            // Speed limits.
+            println!("speed-limit-down-enabled: {}", s.speed_limit_down_enabled);
+            println!("speed-limit-down: {}", s.speed_limit_down);
+            println!("speed-limit-up-enabled: {}", s.speed_limit_up_enabled);
+            println!("speed-limit-up: {}", s.speed_limit_up);
+
+            // Alt speed (turtle mode) limits.
+            println!("alt-speed-enabled: {}", s.alt_speed_enabled);
+            println!("alt-speed-down: {}", s.alt_speed_down);
+            println!("alt-speed-up: {}", s.alt_speed_up);
+            println!("alt-speed-time-enabled: {}", s.alt_speed_time_enabled);
+            println!("alt-speed-time-begin: {}", s.alt_speed_time_begin);
+            println!("alt-speed-time-end: {}", s.alt_speed_time_end);
+            println!("alt-speed-time-day: {}", s.alt_speed_time_day);
+
+            // Queue / idle.
+            println!("download-queue-enabled: {}", s.download_queue_enabled);
+            println!("download-queue-size: {}", s.download_queue_size);
+            println!("seed-queue-enabled: {}", s.seed_queue_enabled);
+            println!("seed-queue-size: {}", s.seed_queue_size);
+            println!("queue-stalled-enabled: {}", s.queue_stalled_enabled);
+            println!("queue-stalled-minutes: {}", s.queue_stalled_minutes);
+            println!(
+                "idle-seeding-limit-enabled: {}",
+                s.idle_seeding_limit_enabled
+            );
+            println!("idle-seeding-limit: {}", s.idle_seeding_limit);
+
+            // Seed-ratio limit.
+            println!("seed-ratio-limited: {}", s.seed_ratio_limited);
+            println!("seed-ratio-limit: {}", s.seed_ratio_limit);
+
+            // Peer limits / misc.
+            println!("peer-limit-global: {}", s.peer_limit_global);
+            println!("peer-limit-per-torrent: {}", s.peer_limit_per_torrent);
+            println!("reqq: {}", s.reqq);
+            println!("sequential-download: {}", s.sequential_download);
+
+            // Scripts.
+            println!(
+                "script-torrent-added-enabled: {}",
+                s.script_torrent_added_enabled
+            );
+            println!(
+                "script-torrent-added-filename: {}",
+                s.script_torrent_added_filename
+            );
+            println!(
+                "script-torrent-done-enabled: {}",
                 s.script_torrent_done_enabled
             );
             println!(
-                "script-torrent-done-filename: {:?}",
+                "script-torrent-done-filename: {}",
                 s.script_torrent_done_filename
             );
-            println!("cache-size-mb: {:?}", s.cache_size_mb);
-            println!("rename-partial-files: {:?}", s.rename_partial_files);
             println!(
-                "trash-original-torrent-files: {:?}",
-                s.trash_original_torrent_files
+                "script-torrent-done-seeding-enabled: {}",
+                s.script_torrent_done_seeding_enabled
             );
-            println!("start-added-torrents: {:?}", s.start_added_torrents);
+            println!(
+                "script-torrent-done-seeding-filename: {}",
+                s.script_torrent_done_seeding_filename
+            );
         }
         Err(_) => panic!("Oh no!"),
     }

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -29,32 +29,122 @@ pub trait RpcResponseArgument {}
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct SessionGet {
+    // Fields without `#[serde(default)]` are required to deserialize.
+    // All others fall back to `T::default()` if the daemon omits them
+    // (Transmission v4+ always emits them).
+    //
+    // Fields with `rename`/`alias` attributes are because the v4
+    // api-compat layer maps them to camelCase / canonical snake_case
+    // rather than the default kebab-case spelling.
+    #[serde(default)]
+    pub alt_speed_down: i32,
+    #[serde(default)]
+    pub alt_speed_enabled: bool,
+    #[serde(default)]
+    pub alt_speed_time_begin: i32,
+    #[serde(default)]
+    pub alt_speed_time_day: i32,
+    #[serde(default)]
+    pub alt_speed_time_enabled: bool,
+    #[serde(default)]
+    pub alt_speed_time_end: i32,
+    #[serde(default)]
+    pub alt_speed_up: i32,
+    #[serde(default)]
+    pub anti_brute_force_enabled: bool,
     pub blocklist_enabled: bool,
+    #[serde(default)]
+    pub blocklist_size: i32,
+    #[serde(default)]
+    pub blocklist_url: String,
+    #[serde(default)]
+    pub cache_size_mb: i32,
+    #[serde(default)]
+    pub config_dir: String,
+    #[serde(default)]
+    pub default_trackers: String,
+    #[serde(default)]
+    pub dht_enabled: bool,
     pub download_dir: String,
+    #[serde(default)]
+    pub download_queue_enabled: bool,
+    #[serde(default)]
+    pub download_queue_size: i32,
     pub encryption: String,
+    #[serde(default)]
+    pub idle_seeding_limit: i32,
+    #[serde(default)]
+    pub idle_seeding_limit_enabled: bool,
+    #[serde(default)]
+    pub incomplete_dir: String,
+    #[serde(default)]
+    pub incomplete_dir_enabled: bool,
+    #[serde(default)]
+    pub lpd_enabled: bool,
+    #[serde(default)]
+    pub peer_limit_global: i32,
+    #[serde(default)]
+    pub peer_limit_per_torrent: i32,
     pub peer_port: i32,
+    #[serde(default)]
+    pub peer_port_random_on_start: bool,
+    #[serde(default)]
+    pub pex_enabled: bool,
+    #[serde(default)]
+    pub port_forwarding_enabled: bool,
+    #[serde(default, rename = "preferred_transports")]
+    pub preferred_transports: Vec<String>,
+    #[serde(default)]
+    pub queue_stalled_enabled: bool,
+    #[serde(default)]
+    pub queue_stalled_minutes: i32,
+    #[serde(default)]
+    pub rename_partial_files: bool,
+    #[serde(default)]
+    pub reqq: i32,
     pub rpc_version: i32,
     pub rpc_version_minimum: i32,
+    #[serde(default)]
+    pub rpc_version_semver: String,
+    #[serde(default)]
+    pub script_torrent_added_enabled: bool,
+    #[serde(default)]
+    pub script_torrent_added_filename: String,
+    #[serde(default)]
+    pub script_torrent_done_enabled: bool,
+    #[serde(default)]
+    pub script_torrent_done_filename: String,
+    #[serde(default)]
+    pub script_torrent_done_seeding_enabled: bool,
+    #[serde(default)]
+    pub script_torrent_done_seeding_filename: String,
+    #[serde(default)]
+    pub seed_queue_enabled: bool,
+    #[serde(default)]
+    pub seed_queue_size: i32,
+    #[serde(default, rename = "seed_ratio_limit", alias = "seedRatioLimit")]
+    pub seed_ratio_limit: f64,
+    #[serde(default, rename = "seed_ratio_limited", alias = "seedRatioLimited")]
+    pub seed_ratio_limited: bool,
+    #[serde(default, rename = "sequential_download")]
+    pub sequential_download: bool,
+    #[serde(default)]
+    pub session_id: String,
+    #[serde(default)]
+    pub speed_limit_down: i32,
+    #[serde(default)]
+    pub speed_limit_down_enabled: bool,
+    #[serde(default)]
+    pub speed_limit_up: i32,
+    #[serde(default)]
+    pub speed_limit_up_enabled: bool,
+    #[serde(default)]
+    pub start_added_torrents: bool,
+    #[serde(default)]
+    pub trash_original_torrent_files: bool,
+    #[serde(default)]
+    pub utp_enabled: bool,
     pub version: String,
-
-    // Fields below are optional to remain compatible with older daemons
-    // that may not include them in the session-get response.
-    #[serde(default)]
-    pub incomplete_dir_enabled: Option<bool>,
-    #[serde(default)]
-    pub incomplete_dir: Option<String>,
-    #[serde(default)]
-    pub script_torrent_done_enabled: Option<bool>,
-    #[serde(default)]
-    pub script_torrent_done_filename: Option<String>,
-    #[serde(default)]
-    pub cache_size_mb: Option<i32>,
-    #[serde(default)]
-    pub rename_partial_files: Option<bool>,
-    #[serde(default)]
-    pub trash_original_torrent_files: Option<bool>,
-    #[serde(default)]
-    pub start_added_torrents: Option<bool>,
 }
 impl RpcResponseArgument for SessionGet {}
 

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -3825,9 +3825,9 @@ fn test_session_get_kebab_minimal() -> Result<()> {
     }"#;
     let s: SessionGet = serde_json::from_str(json)?;
     assert_eq!(s.download_dir, "/down_dir");
-    assert!(
-        s.cache_size_mb.is_none(),
-        "Unsupported server fields shouldn't exist"
+    assert_eq!(
+        s.cache_size_mb, 0,
+        "Missing fields fall back to their type's Default"
     );
     Ok(())
 }
@@ -3853,11 +3853,53 @@ fn test_session_get_kebab_full() -> Result<()> {
         "start-added-torrents": true
     }"#;
     let s: SessionGet = serde_json::from_str(json)?;
-    assert_eq!(s.cache_size_mb, Some(4));
+    assert_eq!(s.cache_size_mb, 4);
     assert_eq!(
-        s.incomplete_dir.as_deref(),
-        Some("/incomplete_dir"),
-        "New fields return a usable Option"
+        s.incomplete_dir, "/incomplete_dir",
+        "New fields hydrate from the response"
     );
+    Ok(())
+}
+
+#[test]
+fn test_session_get_seed_ratio_camel_v4_apicompat() -> Result<()> {
+    use crate::types::SessionGet;
+    // Transmission v4 daemons running the legacy (non-jsonrpc) API style
+    // convert the canonical key `seed_ratio_limit{,ed}` back to camelCase
+    // for backwards compatibility (see libtransmission/api-compat.cc).
+    let json = r#"{
+        "blocklist-enabled": false,
+        "download-dir": "/d",
+        "encryption": "preferred",
+        "peer-port": 51413,
+        "rpc-version": 18,
+        "rpc-version-minimum": 1,
+        "version": "4.2.0",
+        "seedRatioLimit": 1.5,
+        "seedRatioLimited": true
+    }"#;
+    let s: SessionGet = serde_json::from_str(json)?;
+    assert_eq!(s.seed_ratio_limit, 1.5);
+    assert!(s.seed_ratio_limited);
+    Ok(())
+}
+
+#[test]
+fn test_session_get_seed_ratio_snake_v4_canonical() -> Result<()> {
+    use crate::types::SessionGet;
+    let json = r#"{
+        "blocklist-enabled": false,
+        "download-dir": "/d",
+        "encryption": "preferred",
+        "peer-port": 51413,
+        "rpc-version": 18,
+        "rpc-version-minimum": 1,
+        "version": "4.2.0",
+        "seed_ratio_limit": 2.0,
+        "seed_ratio_limited": false
+    }"#;
+    let s: SessionGet = serde_json::from_str(json)?;
+    assert_eq!(s.seed_ratio_limit, 2.0);
+    assert!(!s.seed_ratio_limited);
     Ok(())
 }


### PR DESCRIPTION
Thanks for the last merge! This time I alphabetized the fields. :wink: 

Add remaining possible fields for SessionGet and remove Option from fields they were previously added. Instead, `default` will provide missing values. Transmission v3 compatibility is not considered for these new fields, but camelCase anomalies present
in v4 were accounted for before and during testing. Changes were tested against Transmission 4.1.1.