### PR TITLE
Replace encryption option with enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ When running tests, ensure to start a clean instance of transmission with RPC ("
 
 
 ```
-cargo test -- --skip session_close && cargo test -- session_close
+cargo clean && cargo test -- --skip session_close && cargo test -- session_close
 ```
 
-If transmission is crashing with segmentation fault, try running the tests sequentially.
+If Transmission is crashing with segmentation fault, try running the tests sequentially.
 
 ```
 cargo test -- --test-threads=1 --skip session_close

--- a/examples/session-get.rs
+++ b/examples/session-get.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
                 s.trash_original_torrent_files
             );
             println!("start-added-torrents: {}", s.start_added_torrents);
-            println!("encryption: {:?}", s.encryption);
+            println!("encryption: {}", s.encryption);
             println!("cache-size-mb: {}", s.cache_size_mb);
             println!("default-trackers: {}", s.default_trackers);
 

--- a/examples/session-get.rs
+++ b/examples/session-get.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
                 s.trash_original_torrent_files
             );
             println!("start-added-torrents: {}", s.start_added_torrents);
-            println!("encryption: {}", s.encryption);
+            println!("encryption: {:?}", s.encryption);
             println!("cache-size-mb: {}", s.cache_size_mb);
             println!("default-trackers: {}", s.default_trackers);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,10 +27,31 @@ mod tests;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BandwidthGroup {
+    #[serde(rename = "honorsSessionLimits")]
+    pub honors_session_limits: bool,
+    pub name: String,
+    pub speed_limit_down_enabled: bool,
+    pub speed_limit_down: u64,
+    pub speed_limit_up_enabled: bool,
+    pub speed_limit_up: u64,
+}
+
 #[derive(Debug, Clone)]
 pub struct BasicAuth {
     pub user: String,
     pub password: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Encryption {
+    #[default]
+    Preferred,
+    Required,
+    Tolerated,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -62,16 +83,4 @@ pub enum RatioMode {
     Global = 0,
     Single = 1,
     Unlimited = 2,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct BandwidthGroup {
-    #[serde(rename = "honorsSessionLimits")]
-    pub honors_session_limits: bool,
-    pub name: String,
-    pub speed_limit_down_enabled: bool,
-    pub speed_limit_down: u64,
-    pub speed_limit_up_enabled: bool,
-    pub speed_limit_up: u64,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 J0rsa and contributors
 // SPDX-License-Identifier: MIT
 
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -45,13 +47,18 @@ pub struct BasicAuth {
     pub password: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Encryption {
-    #[default]
     Preferred,
     Required,
     Tolerated,
+}
+
+impl fmt::Display for Encryption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&format!("{self:?}").to_lowercase())
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 J0rsa and contributors
 // SPDX-License-Identifier: MIT
 
-use super::{Id, IdleMode, Priority, RatioMode};
+use super::{Encryption, Id, IdleMode, Priority, RatioMode};
 use enum_iterator::{all, Sequence};
 use serde::{Serialize, Serializer};
 use serde_with::skip_serializing_none;
@@ -291,7 +291,7 @@ pub struct SessionSetArgs {
     pub download_dir_free_space: Option<i32>,
     pub download_queue_enabled: Option<bool>,
     pub download_queue_size: Option<i32>,
-    pub encryption: Option<String>,
+    pub encryption: Option<Encryption>,
     pub idle_seeding_limit_enabled: Option<bool>,
     pub idle_seeding_limit: Option<i32>,
     pub incomplete_dir_enabled: Option<bool>,

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use serde_repr::*;
 
-use super::{BandwidthGroup, Id, IdleMode, Priority, RatioMode};
+use super::{BandwidthGroup, Encryption, Id, IdleMode, Priority, RatioMode};
 
 #[derive(Deserialize, Debug)]
 pub struct RpcResponse<T: RpcResponseArgument> {
@@ -70,7 +70,7 @@ pub struct SessionGet {
     pub download_queue_enabled: bool,
     #[serde(default)]
     pub download_queue_size: i32,
-    pub encryption: String,
+    pub encryption: Encryption,
     #[serde(default)]
     pub idle_seeding_limit: i32,
     #[serde(default)]

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -3825,6 +3825,7 @@ fn test_session_get_kebab_minimal() -> Result<()> {
     }"#;
     let s: SessionGet = serde_json::from_str(json)?;
     assert_eq!(s.download_dir, "/down_dir");
+    assert_eq!(s.encryption, crate::types::Encryption::Preferred);
     assert_eq!(
         s.cache_size_mb, 0,
         "Missing fields fall back to their type's Default"
@@ -3837,7 +3838,7 @@ fn test_session_get_kebab_full() -> Result<()> {
     use crate::types::SessionGet;
     let json = r#"{
         "blocklist-enabled": false,
-        "download-dir": "/d",
+        "download-dir": "/down-dir",
         "encryption": "preferred",
         "peer-port": 51413,
         "rpc-version": 18,
@@ -3869,7 +3870,7 @@ fn test_session_get_seed_ratio_camel_v4_apicompat() -> Result<()> {
     // for backwards compatibility (see libtransmission/api-compat.cc).
     let json = r#"{
         "blocklist-enabled": false,
-        "download-dir": "/d",
+        "download-dir": "/down-dir",
         "encryption": "preferred",
         "peer-port": 51413,
         "rpc-version": 18,
@@ -3889,7 +3890,7 @@ fn test_session_get_seed_ratio_snake_v4_canonical() -> Result<()> {
     use crate::types::SessionGet;
     let json = r#"{
         "blocklist-enabled": false,
-        "download-dir": "/d",
+        "download-dir": "/down-dir",
         "encryption": "preferred",
         "peer-port": 51413,
         "rpc-version": 18,
@@ -3901,5 +3902,38 @@ fn test_session_get_seed_ratio_snake_v4_canonical() -> Result<()> {
     let s: SessionGet = serde_json::from_str(json)?;
     assert_eq!(s.seed_ratio_limit, 2.0);
     assert!(!s.seed_ratio_limited);
+    Ok(())
+}
+
+#[test]
+fn test_session_get_encryption_variants() -> Result<()> {
+    use crate::types::{Encryption, SessionGet};
+
+    fn parse(value: &str) -> Encryption {
+        let json = format!(
+            r#"{{"blocklist-enabled":false,"download-dir":"/down-dir","encryption":"{value}","peer-port":51413,"rpc-version":18,"rpc-version-minimum":1,"version":"4.0.5"}}"#
+        );
+        let s: SessionGet = serde_json::from_str(&json).unwrap();
+        s.encryption
+    }
+
+    assert_eq!(parse("preferred"), Encryption::Preferred);
+    assert_eq!(parse("required"), Encryption::Required);
+    assert_eq!(parse("tolerated"), Encryption::Tolerated);
+
+    // round-trip: Encryption serializes back to the same lowercase string
+    assert_eq!(
+        serde_json::to_string(&Encryption::Preferred).unwrap(),
+        r#""preferred""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Encryption::Required).unwrap(),
+        r#""required""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Encryption::Tolerated).unwrap(),
+        r#""tolerated""#
+    );
+
     Ok(())
 }


### PR DESCRIPTION
Replace string option for Encryption with enum.

@red-avtovo maybe we can squeeze this in before a 1.0 since it would be a breaking api change?