### PR TITLE
Add torrent_get_recently_active()

### DIFF
--- a/examples/torrent-get-recently-active.rs
+++ b/examples/torrent-get-recently-active.rs
@@ -1,0 +1,113 @@
+extern crate transmission_rpc;
+
+use std::env;
+use std::time::Duration;
+
+use dotenvy::dotenv;
+use tokio::time::sleep;
+use transmission_rpc::types::{
+    BasicAuth, Id, Result, RpcResponse, Torrent, TorrentGetField, TorrentGetIds, Torrents,
+};
+use transmission_rpc::TransClient;
+
+/// Demonstrates `TorrentGetIds` and the `recently-active` polling pattern, a
+/// method to optimize RPC bandwidth and eliminate sending redundant torrent data.
+/// - First, a full fetch via torrent_get
+/// - Second, a targeted fetch with TorrentGetIds
+/// - Third, `recently-active` returns only torrents whose state has changes
+///   since its previous call. Alongside is a list of `removed` ids the daemon
+///   has deleted.
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv().ok();
+    env_logger::init();
+    let url = env::var("TURL")?;
+    let mut client = if let (Ok(user), Ok(password)) = (env::var("TUSER"), env::var("TPWD")) {
+        TransClient::with_auth(url.parse()?, BasicAuth { user, password })
+    } else {
+        TransClient::new(url.parse()?)
+    };
+
+    let table_fields = vec![
+        TorrentGetField::Id,
+        TorrentGetField::HashString,
+        TorrentGetField::Name,
+        TorrentGetField::PercentDone,
+        TorrentGetField::RateDownload,
+        TorrentGetField::RateUpload,
+    ];
+
+    // 1. Seed the local view with a full fetch via torrent_get,
+    //   `TorrentGetIds::Ids(vec![])` is simply expressed as `None`.
+    //   After this call the daemon starts tracking which torrents
+    //   change for the recently-active sentinel on subsequent requests
+    //   issued over the same session.
+    let seed: RpcResponse<Torrents<Torrent>> =
+        client.torrent_get(Some(table_fields.clone()), None).await?;
+    println!(
+        "seed: {} torrents, {} removed",
+        seed.arguments.torrents.len(),
+        seed.arguments.removed.len()
+    );
+
+    // 2. Targeted fetch built explicitly via `TorrentGetIds::Ids`. Prefer
+    // info-hash ids over numeric ids: integer ids are session-scoped and not
+    // stable across Transmission daemon restarts, while the 40-character
+    // info-hash uniquely identifies a torrent for its lifetime. The
+    // `From<Vec<Id>>` impl makes `.into()` work too, but spelling out the
+    // variant is useful when matching on it elsewhere.
+    if let Some(hash) = seed
+        .arguments
+        .torrents
+        .first()
+        .and_then(|t| t.hash_string.clone())
+    {
+        let targeted_ids = TorrentGetIds::Ids(vec![Id::Hash(hash)]);
+        if let TorrentGetIds::Ids(ref ids) = targeted_ids {
+            let res: RpcResponse<Torrents<Torrent>> = client
+                .torrent_get(Some(table_fields.clone()), Some(ids.clone()))
+                .await?;
+            for t in &res.arguments.torrents {
+                println!(
+                    "hash={} name={:?} done={:.1}%",
+                    t.hash_string.as_deref().unwrap_or("(none)"),
+                    t.name.as_deref().unwrap_or("(none)"),
+                    t.percent_done.unwrap_or(0.0) * 100.0,
+                );
+            }
+        }
+    }
+
+    // 3. Poll three times using the `recently-active` sentinel. Each tick
+    // returns only the torrents that changed since the previous call plus a
+    // `removed` list of ids the daemon has deleted. The first tick after the
+    // seed typically reports just torrents whose stats moved (rates, eta,
+    // ...) perfect for cheap UI refreshes.
+    for tick in 1..=3 {
+        sleep(Duration::from_secs(2)).await;
+        let res: RpcResponse<Torrents<Torrent>> = client
+            .torrent_get_recently_active(Some(table_fields.clone()))
+            .await?;
+        println!(
+            "tick {tick}: {} changed, {} removed",
+            res.arguments.torrents.len(),
+            res.arguments.removed.len()
+        );
+        for t in &res.arguments.torrents {
+            println!(
+                "  changed hash={} ↓{}B/s ↑{}B/s",
+                t.hash_string.as_deref().unwrap_or("(none)"),
+                t.rate_download.unwrap_or(0),
+                t.rate_upload.unwrap_or(0),
+            );
+        }
+        // The `removed` list is protocol-defined as numeric ids only; there
+        // is no hash equivalent on the wire. Map them back to hashes via a
+        // local id -> hash table if you need a stable identifier.
+        for id in &res.arguments.removed {
+            println!("  removed id={id}");
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,6 +785,18 @@ impl TransClient {
         self.call(RpcRequest::torrent_get(fields, ids)).await
     }
 
+    /// Like [`Self::torrent_get`] but uses the Transmission `"recently-active"`
+    /// id sentinel: the daemon returns only torrents whose state has changed
+    /// since the previous recently-active call, plus a `removed` list of ids
+    /// that have been deleted in the meantime.
+    pub async fn torrent_get_recently_active(
+        &mut self,
+        fields: Option<Vec<TorrentGetField>>,
+    ) -> Result<RpcResponse<Torrents<Torrent>>> {
+        self.call(RpcRequest::torrent_get_recently_active(fields))
+            .await
+    }
+
     /// Performs a torrent set call
     /// args - the fields to update
     /// ids - if None then All items

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -430,6 +430,18 @@ impl SharableTransClient {
         self.call(RpcRequest::torrent_get(fields, ids)).await
     }
 
+    /// Like [`Self::torrent_get`] but uses the Transmission `"recently-active"`
+    /// id sentinel: the daemon returns only torrents whose state has changed
+    /// since the previous recently-active call, plus a `removed` list of ids
+    /// that have been deleted in the meantime.
+    pub async fn torrent_get_recently_active(
+        &self,
+        fields: Option<Vec<TorrentGetField>>,
+    ) -> Result<RpcResponse<Torrents<Torrent>>> {
+        self.call(RpcRequest::torrent_get_recently_active(fields))
+            .await
+    }
+
     /// Performs a torrent set call
     /// args - the fields to update
     /// ids - if None then All items

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 pub(crate) use self::request::RpcRequest;
 pub use self::request::{
-    ArgumentFields, SessionSetArgs, TorrentAction, TorrentAddArgs, TorrentGetField,
+    ArgumentFields, SessionSetArgs, TorrentAction, TorrentAddArgs, TorrentGetField, TorrentGetIds,
     TorrentRenamePathArgs, TorrentSetArgs, TrackerList,
 };
 

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -112,6 +112,20 @@ impl RpcRequest {
     }
 
     pub fn torrent_get(fields: Option<Vec<TorrentGetField>>, ids: Option<Vec<Id>>) -> RpcRequest {
+        Self::torrent_get_with(fields, ids.map(TorrentGetIds::Ids))
+    }
+
+    /// Like [`Self::torrent_get`] but instructs the daemon to return only
+    /// torrents whose state has changed since the previous "recently-active"
+    /// call. The response also includes a `removed` array of torrent ids.
+    pub fn torrent_get_recently_active(fields: Option<Vec<TorrentGetField>>) -> RpcRequest {
+        Self::torrent_get_with(fields, Some(TorrentGetIds::RecentlyActive))
+    }
+
+    fn torrent_get_with(
+        fields: Option<Vec<TorrentGetField>>,
+        ids: Option<TorrentGetIds>,
+    ) -> RpcRequest {
         let fields = fields.unwrap_or_else(|| all::<TorrentGetField>().collect());
         let args = TorrentGetArgs {
             fields: fields.into(),
@@ -345,12 +359,39 @@ pub struct BandwidthGroupGetArgs {
     name: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+pub enum TorrentGetIds {
+    /// One or more explicit torrent ids/hashes.
+    Ids(Vec<Id>),
+    /// The Transmission RPC sentinel `"recently-active"` — match torrents whose
+    /// state has changed since the previous `torrent-get` recently-active call.
+    RecentlyActive,
+}
+
+impl Serialize for TorrentGetIds {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            TorrentGetIds::Ids(ids) => ids.serialize(serializer),
+            TorrentGetIds::RecentlyActive => serializer.serialize_str("recently-active"),
+        }
+    }
+}
+
+impl From<Vec<Id>> for TorrentGetIds {
+    fn from(ids: Vec<Id>) -> Self {
+        TorrentGetIds::Ids(ids)
+    }
+}
+
 #[derive(Serialize, Debug, Clone)]
 pub struct TorrentGetArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     fields: Option<Vec<TorrentGetField>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ids: Option<Vec<Id>>,
+    ids: Option<TorrentGetIds>,
 }
 
 impl Default for TorrentGetArgs {

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -391,6 +391,10 @@ pub struct Stats {
 #[derive(Deserialize, Debug)]
 pub struct Torrents<T> {
     pub torrents: Vec<T>,
+    /// Populated only by `torrent-get` calls with `ids = "recently-active"`.
+    /// Lists ids of torrents that have been removed since the previous call.
+    #[serde(default)]
+    pub removed: Vec<i64>,
 }
 impl RpcResponseArgument for Torrents<Torrent> {}
 


### PR DESCRIPTION
This adds support for patched updates to optimize bandwidth usage in large sessions where redundant data can be an issue.  
This introduces the method `torrent_get_recently_active()` and complimentary GetTorrentIds struct for interfacing with `recently-active`. See: https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#31-torrent-action-requests

Basically `torrent_get_recently_active()` works like `torrent_get()` but instructs the daemon to return only torrents whose state has changed since the previous "recently-active" call. See the added example for more implementation details.

This will be my final api-breaking change as my transmission-client is nearing feature completion (which I'd be happy to share once stable). Thank you again.

Example output for a most-inactive session:

```
$ cargo run --example torrent-get-recently-active
seed: 3 torrents, 0 removed
hash=e1fc140a6391357fa1cf08ddb70274f9c05eb88b name="ubuntu-26.04-live-server-amd64.iso" done=0.0%
tick 1: 0 changed, 0 removed
tick 2: 0 changed, 0 removed
tick 3: 0 changed, 0 removed
```

For a moderate session of 2-4 active torrents and ~50 seeding torrents I see bandwidth usage drop from 20KB per tick to 2KB.